### PR TITLE
Add ability to have a custom Msg

### DIFF
--- a/examples/elm-css/src/Chapters/Testing.elm
+++ b/examples/elm-css/src/Chapters/Testing.elm
@@ -5,7 +5,7 @@ import ElmBook.ElmCSS exposing (Chapter)
 import Html.Styled exposing (div, p, text)
 
 
-chapter_ : Chapter x
+chapter_ : Chapter x y
 chapter_ =
     chapter "Testing…"
         |> renderComponent

--- a/examples/elm-css/src/ElmBook/ElmCSS.elm
+++ b/examples/elm-css/src/ElmBook/ElmCSS.elm
@@ -4,22 +4,22 @@ import ElmBook.Custom exposing (customBook)
 import Html.Styled
 
 
-type alias Html state =
-    Html.Styled.Html (ElmBook.Custom.Msg state)
+type alias Html state subMsg =
+    Html.Styled.Html (ElmBook.Custom.Msg state subMsg) 
 
 
-type alias BookBuilder state =
-    ElmBook.Custom.BookBuilder state (Html state)
+type alias BookBuilder state subMsg =
+    ElmBook.Custom.BookBuilder state (Html state subMsg) subMsg
 
 
-type alias Book state =
-    ElmBook.Custom.Book state (Html state)
+type alias Book state subMsg =
+    ElmBook.Custom.Book state (Html state subMsg) subMsg
 
 
-type alias Chapter state =
-    ElmBook.Custom.Chapter state (Html state)
+type alias Chapter state subMsg =
+    ElmBook.Custom.Chapter state (Html state subMsg)
 
 
-book : String -> BookBuilder state
+book : String -> BookBuilder state subMsg
 book =
     customBook Html.Styled.toUnstyled

--- a/examples/elm-css/src/ElmBook/ElmCSS.elm
+++ b/examples/elm-css/src/ElmBook/ElmCSS.elm
@@ -5,7 +5,7 @@ import Html.Styled
 
 
 type alias Html state subMsg =
-    Html.Styled.Html (ElmBook.Custom.Msg state subMsg) 
+    Html.Styled.Html (ElmBook.Custom.Msg state subMsg)
 
 
 type alias BookBuilder state subMsg =

--- a/examples/elm-css/src/Main.elm
+++ b/examples/elm-css/src/Main.elm
@@ -5,7 +5,7 @@ import ElmBook exposing (withChapters)
 import ElmBook.ElmCSS exposing (Book, book)
 
 
-main : Book ()
+main : Book () ()
 main =
     book "Elm-UI"
         |> withChapters

--- a/examples/elm-ui/src/Chapters/Testing.elm
+++ b/examples/elm-ui/src/Chapters/Testing.elm
@@ -5,7 +5,7 @@ import ElmBook.Chapter exposing (chapter, renderComponent)
 import ElmBook.ElmUI exposing (Chapter)
 
 
-chapter_ : Chapter x
+chapter_ : Chapter x y
 chapter_ =
     chapter "Testing…"
         |> renderComponent

--- a/examples/elm-ui/src/ElmBook/ElmUI.elm
+++ b/examples/elm-ui/src/ElmBook/ElmUI.elm
@@ -4,22 +4,22 @@ import Element exposing (Element, layout)
 import ElmBook.Custom exposing (customBook)
 
 
-type alias Html state =
-    Element (ElmBook.Custom.Msg state)
+type alias Html state subMsg =
+    Element (ElmBook.Custom.Msg state subMsg)
 
 
-type alias BookBuilder state =
-    ElmBook.Custom.BookBuilder state (Html state)
+type alias BookBuilder state subMsg =
+    ElmBook.Custom.BookBuilder state (Html state subMsg) subMsg
 
 
-type alias Book state =
-    ElmBook.Custom.Book state (Html state)
+type alias Book state subMsg =
+    ElmBook.Custom.Book state (Html state subMsg) subMsg
 
 
-type alias Chapter state =
-    ElmBook.Custom.Chapter state (Html state)
+type alias Chapter state subMsg =
+    ElmBook.Custom.Chapter state (Html state subMsg)
 
 
-book : String -> BookBuilder state
+book : String -> BookBuilder state subMsg
 book =
     customBook (layout [])

--- a/examples/elm-ui/src/Main.elm
+++ b/examples/elm-ui/src/Main.elm
@@ -5,7 +5,7 @@ import ElmBook exposing (withChapters)
 import ElmBook.ElmUI exposing (Book, book)
 
 
-main : Book ()
+main : Book () ()
 main =
     book "Elm-UI"
         |> withChapters

--- a/src/ElmBook.elm
+++ b/src/ElmBook.elm
@@ -13,7 +13,7 @@ Check out the ["Books"](https://elm-book-in-elm-book.netlify.app/guides/books) g
 
 This module is used to create your books main output. You need to list your book's chapters here and also provide any global options you may want to define.
 
-    main : Book ()
+    main : Book () ()
     main =
         book "My Book"
             |> withChapters
@@ -55,7 +55,7 @@ import Html exposing (Html)
 
 If you're working with something other than `elm/html` (e.g. elm-css or elm-ui) then check out the `ElmBook.Custom` module.
 
-If you're creating a stateful book, you will need to pass your custom `SharedState` as an argument as showcased below.
+If you're creating a stateful book, you will need to pass your custom `SharedState` as an argument as showcased below. If you're using your own `Msg` and `update`, you need to pass it as the second argument.
 
     import FirstChapter
     import SecondChapter
@@ -71,12 +71,29 @@ If you're creating a stateful book, you will need to pass your custom `SharedSta
         , secondChapter = SecondChapter.init
         }
 
-    main : Book SharedState
+    type Msg
+        = GotFirstChapterMsg FirstChapter.Msg
+        | GotSecondChapterMsg SecondChapter.Msg
+
+    update : Msg -> SharedState -> ( SharedState, Cmd Msg )
+    update msg sharedState =
+        case msg of
+            GotFirstChapterMsg subMsg ->
+                FirstChapter.update subMsg sharedState
+                    |> Tuple.mapSecond (Cmd.map GotFirstChapterMsg)
+
+            GotFirstChapterMsg subMsg ->
+                SecondChapter.update subMsg sharedState
+                    |> Tuple.mapSecond (Cmd.map GotSecondChapterMsg)
+
+    main : Book SharedState Msg
     main =
         book "MyApp"
             |> withStatefulOptions
                 [ ElmBook.StatefulOptions.initialState
                     initialState
+                , ElmBook.StatefulOptions.update
+                    update
                 ]
 
 -}
@@ -144,7 +161,7 @@ withChapterGroups chapterGroups_ =
 
 {-| You can customize your book with any of the options available on the `ElmBook.Theme` module. Take a look at the ["Theming"](https://elm-book-in-elm-book.netlify.app/guides/theming) guide for some examples.
 
-    main : Book x
+    main : Book x y
     main =
         book "My Themed Book"
             |> withThemeOptions
@@ -184,7 +201,7 @@ withChapterOptions attributes (BookBuilder config) =
 
 {-| By default, your components will appear inside a card with some padding and a label at the top. You can customize all of that with this function and the attributes available on `ElmBook.ComponentOptions`.
 
-    main : Book ()
+    main : Book () ()
     main =
         book "My Book"
             |> withComponentOptions

--- a/src/ElmBook.elm
+++ b/src/ElmBook.elm
@@ -80,18 +80,18 @@ If you're creating a stateful book, you will need to pass your custom `SharedSta
                 ]
 
 -}
-type alias Book state =
-    BookApplication state (Html (Msg state))
+type alias Book state subMsg =
+    BookApplication state (Html (Msg state subMsg)) subMsg
 
 
 {-| -}
-type alias Msg state =
-    ElmBook.Internal.Msg.Msg state
+type alias Msg state subMsg =
+    ElmBook.Internal.Msg.Msg state subMsg
 
 
 {-| Kickoff the creation of an ElmBook application.
 -}
-book : String -> BookBuilder state (Html (Msg state))
+book : String -> BookBuilder state (Html (Msg state subMsg)) subMsg
 book =
     ElmBook.Custom.customBook identity
 
@@ -101,7 +101,7 @@ book =
 **Should be used as the final step on your setup.**
 
 -}
-withChapters : List (ChapterCustom state html) -> BookBuilder state html -> BookApplication state html
+withChapters : List (ChapterCustom state html) -> BookBuilder state html subMsg -> BookApplication state html subMsg
 withChapters chapters =
     withChapterGroups [ ( "", chapters ) ]
 
@@ -128,8 +128,8 @@ withChapters chapters =
 -}
 withChapterGroups :
     List ( String, List (ChapterCustom state html) )
-    -> BookBuilder state html
-    -> BookApplication state html
+    -> BookBuilder state html subMsg
+    -> BookApplication state html subMsg
 withChapterGroups chapterGroups_ =
     ElmBook.Internal.Application.application
         (chapterGroups_
@@ -155,7 +155,7 @@ withChapterGroups chapterGroups_ =
             |> withChapters []
 
 -}
-withThemeOptions : List (ElmBook.ThemeOptions.ThemeOption html) -> BookBuilder state html -> BookBuilder state html
+withThemeOptions : List (ElmBook.ThemeOptions.ThemeOption html) -> BookBuilder state html subMsg -> BookBuilder state html subMsg
 withThemeOptions themeAttributes (BookBuilder config) =
     BookBuilder
         { config | themeOptions = applyAttributes themeAttributes config.themeOptions }
@@ -172,7 +172,7 @@ withThemeOptions themeAttributes (BookBuilder config) =
 Please note that chapter options are "inherited". So you can also override these options on a particular chapter and that will take priority of book-wide options. Take a look at `ElmBook.ChapterOptions` for all the options available.
 
 -}
-withChapterOptions : List ElmBook.ChapterOptions.Attribute -> BookBuilder state html -> BookBuilder state html
+withChapterOptions : List ElmBook.ChapterOptions.Attribute -> BookBuilder state html subMsg -> BookBuilder state html subMsg
 withChapterOptions attributes (BookBuilder config) =
     BookBuilder
         { config
@@ -196,7 +196,7 @@ withChapterOptions attributes (BookBuilder config) =
 Please note that component options are "inherited". So you can override these options on a particular chapter and even on an specific component.
 
 -}
-withComponentOptions : List ElmBook.Internal.ComponentOptions.Attribute -> BookBuilder state html -> BookBuilder state html
+withComponentOptions : List ElmBook.Internal.ComponentOptions.Attribute -> BookBuilder state html subMsg -> BookBuilder state html subMsg
 withComponentOptions componentAttributes (BookBuilder config) =
     BookBuilder
         { config
@@ -212,9 +212,9 @@ Attributes for this function are defined on `ElmBook.StatefulOptions`.
 
 -}
 withStatefulOptions :
-    List (ElmBook.StatefulOptions.Attribute state)
-    -> BookBuilder state html
-    -> BookBuilder state html
+    List (ElmBook.StatefulOptions.Attribute state subMsg)
+    -> BookBuilder state html subMsg
+    -> BookBuilder state html subMsg
 withStatefulOptions attributes (BookBuilder config) =
     BookBuilder
         { config | statefulOptions = applyAttributes attributes config.statefulOptions }

--- a/src/ElmBook/Actions.elm
+++ b/src/ElmBook/Actions.elm
@@ -35,7 +35,7 @@ import ElmBook.Internal.Msg exposing (..)
     button [ onClick <| logAction "Clicked!" ] []
 
 -}
-logAction : String -> Msg state
+logAction : String -> Msg state subMsg
 logAction action =
     LogAction "" action
 
@@ -46,7 +46,7 @@ logAction action =
     input [ onInput <| logActionWithString "Input" ] []
 
 -}
-logActionWithString : String -> String -> Msg state
+logActionWithString : String -> String -> Msg state subMsg
 logActionWithString =
     logActionWith identity
 
@@ -61,7 +61,7 @@ Until then please use the following replacement:
     logActionWith String.fromInt
 
 -}
-logActionWithInt : String -> String -> Msg state
+logActionWithInt : String -> String -> Msg state subMsg
 logActionWithInt =
     logActionWith identity
 
@@ -76,14 +76,14 @@ Until then please use the following replacement:
     logActionWith String.fromFloat
 
 -}
-logActionWithFloat : String -> String -> Msg state
+logActionWithFloat : String -> String -> Msg state subMsg
 logActionWithFloat =
     logActionWith identity
 
 
 {-| Logs an action that takes one `Bool` input.
 -}
-logActionWithBool : String -> Bool -> Msg state
+logActionWithBool : String -> Bool -> Msg state subMsg
 logActionWithBool =
     logActionWith stringFromBool
 
@@ -116,7 +116,7 @@ stringFromBool value =
     }
 
 -}
-logActionWith : (value -> String) -> String -> value -> Msg state
+logActionWith : (value -> String) -> String -> value -> Msg state subMsg
 logActionWith toString action value =
     LogAction "" (action ++ ": " ++ toString value)
 
@@ -142,7 +142,7 @@ logActionWith toString action value =
                 )
 
 -}
-updateState : (state -> state) -> Msg state
+updateState : (state -> state) -> Msg state subMsg
 updateState fn =
     UpdateState (\state -> ( fn state, Cmd.none ))
 
@@ -166,7 +166,7 @@ updateState fn =
                 )
 
 -}
-updateStateWith : (a -> state -> state) -> a -> Msg state
+updateStateWith : (a -> state -> state) -> a -> Msg state subMsg
 updateStateWith fn a =
     UpdateState (\state -> ( fn a state, Cmd.none ))
 
@@ -194,13 +194,13 @@ updateStateWith fn a =
                 )
 
 -}
-updateStateWithCmd : (state -> ( state, Cmd (Msg state) )) -> Msg state
+updateStateWithCmd : (state -> ( state, Cmd (Msg state subMsg) )) -> Msg state subMsg
 updateStateWithCmd =
     UpdateState
 
 
 {-| Same as `updateStateWith` but should return a `( state, Cmd msg )` tuple.
 -}
-updateStateWithCmdWith : (a -> state -> ( state, Cmd (Msg state) )) -> a -> Msg state
+updateStateWithCmdWith : (a -> state -> ( state, Cmd (Msg state subMsg) )) -> a -> Msg state subMsg
 updateStateWithCmdWith fn =
     UpdateState << fn

--- a/src/ElmBook/Actions.elm
+++ b/src/ElmBook/Actions.elm
@@ -8,6 +8,8 @@ module ElmBook.Actions exposing
   - **log actions** will not deal with any state. They will just print out some message to the action logger. This is pretty useful to get things running quickly.
   - **update actions** are used to update your book's shared state. A bit trickier to use but you can do a lot more powerful things with it.
 
+If you want to create your own custom actions, take a look at [`StatefulOptions.update`](ElmBook-StatefulOptions#update).
+
 
 # Logging Actions
 
@@ -127,7 +129,7 @@ logActionWith toString action value =
 
 {-| Updates the state of your stateful book.
 
-    counterChapter : Chapter { x | counter : Int }
+    counterChapter : Chapter { x | counter : Int } subMsg
     counterChapter =
         let
             update state =
@@ -149,7 +151,7 @@ updateState fn =
 
 {-| Used when updating the state based on an argument.
 
-    inputChapter : Chapter { x | input : String }
+    inputChapter : Chapter { x | input : String } subMsg
     inputChapter =
         let
             updateInput value state =
@@ -173,7 +175,7 @@ updateStateWith fn a =
 
 {-| Updates the state of your stateful book and possibly sends out a command. HTTP requests inside your book? Oh yeah! Get ready to go full over-engineering master.
 
-    counterChapter : Chapter { x | counter : Int }
+    counterChapter : Chapter { x | counter : Int } subMsg
     counterChapter =
         let
             fetchCurrentCounter state =
@@ -199,7 +201,7 @@ updateStateWithCmd =
     UpdateState
 
 
-{-| Same as `updateStateWith` but should return a `( state, Cmd msg )` tuple.
+{-| Same as `updateStateWith` but should return a `( state, Cmd (Msg state subMsg) )` tuple.
 -}
 updateStateWithCmdWith : (a -> state -> ( state, Cmd (Msg state subMsg) )) -> a -> Msg state subMsg
 updateStateWithCmdWith fn =

--- a/src/ElmBook/Chapter.elm
+++ b/src/ElmBook/Chapter.elm
@@ -1,7 +1,7 @@
 module ElmBook.Chapter exposing
     ( chapter, chapterLink, renderComponent, renderComponentList, Chapter
     , withComponent, withComponentList, render, renderWithComponentList
-    , withStatefulComponent, withStatefulComponentList, renderStatefulComponent, renderStatefulComponentList, map
+    , withStatefulComponent, withStatefulComponentList, renderStatefulComponent, renderStatefulComponentList, CustomChapter, map, mapCustom
     , withChapterOptions, withComponentOptions
     )
 
@@ -69,7 +69,7 @@ Create chapters with interactive components that can read and update the book's 
 
 Take a look at the ["Stateful Chapters"](https://elm-book-in-elm-book.netlify.app/guides/stateful-chapters) guide for a more throughout explanation.
 
-@docs withStatefulComponent, withStatefulComponentList, renderStatefulComponent, renderStatefulComponentList, map
+@docs withStatefulComponent, withStatefulComponentList, renderStatefulComponent, renderStatefulComponentList, CustomChapter, map, mapCustom
 
 
 # Customizing Chapters
@@ -82,7 +82,7 @@ import ElmBook.ChapterOptions
 import ElmBook.Internal.Chapter exposing (ChapterBuilder(..), ChapterComponent, ChapterComponentView(..), ChapterCustom(..), ChapterOptions(..))
 import ElmBook.Internal.ComponentOptions
 import ElmBook.Internal.Helpers exposing (applyAttributes, toSlug)
-import ElmBook.Internal.Msg exposing (Msg)
+import ElmBook.Internal.Msg as Msg exposing (Msg)
 import Html exposing (Html)
 
 
@@ -90,6 +90,12 @@ import Html exposing (Html)
 -}
 type alias Chapter state subMsg =
     ElmBook.Internal.Chapter.ChapterCustom state (Html (Msg state subMsg))
+
+
+{-| Defines a Chapter type. Use this instead of the regular `Chapter` if you want to use your own `Msg` type, along with `StatefulOptions.update`
+-}
+type alias CustomChapter state subMsg =
+    ElmBook.Internal.Chapter.ChapterCustom state (Html subMsg)
 
 
 {-| Creates a chapter with some title.
@@ -303,7 +309,14 @@ renderWithComponentList body (ChapterBuilder builder) =
 -}
 map : (subMsg -> mappedSubMsg) -> Chapter state subMsg -> Chapter state mappedSubMsg
 map mapMsg chapter_ =
-    ElmBook.Internal.Chapter.map (Html.map (ElmBook.Internal.Msg.map mapMsg)) chapter_
+    ElmBook.Internal.Chapter.map (Html.map (Msg.map mapMsg)) chapter_
+
+
+{-| Similar to `map`, but with a `CustomChapter`
+-}
+mapCustom : (subMsg -> mappedSubMsg) -> CustomChapter state subMsg -> Chapter state mappedSubMsg
+mapCustom mapMsg chapter_ =
+    ElmBook.Internal.Chapter.map (Html.map (mapMsg >> Msg.GotCustomMsg)) chapter_
 
 
 

--- a/src/ElmBook/Chapter.elm
+++ b/src/ElmBook/Chapter.elm
@@ -88,8 +88,8 @@ import Html exposing (Html)
 
 {-| Defines a Chapter type. The argument is the shared state this chapter depends on. We can leave it blank (`x`) on stateless chapters. Read the ["Stateful Chapters"](https://elm-book-in-elm-book.netlify.app/guides/stateful-chapters) guide to know more.
 -}
-type alias Chapter state =
-    ElmBook.Internal.Chapter.ChapterCustom state (Html (Msg state))
+type alias Chapter state subMsg =
+    ElmBook.Internal.Chapter.ChapterCustom state (Html (Msg state subMsg))
 
 
 {-| Creates a chapter with some title.

--- a/src/ElmBook/Chapter.elm
+++ b/src/ElmBook/Chapter.elm
@@ -1,7 +1,7 @@
 module ElmBook.Chapter exposing
     ( chapter, chapterLink, renderComponent, renderComponentList, Chapter
     , withComponent, withComponentList, render, renderWithComponentList
-    , withStatefulComponent, withStatefulComponentList, renderStatefulComponent, renderStatefulComponentList
+    , withStatefulComponent, withStatefulComponentList, renderStatefulComponent, renderStatefulComponentList, map
     , withChapterOptions, withComponentOptions
     )
 
@@ -69,7 +69,7 @@ Create chapters with interactive components that can read and update the book's 
 
 Take a look at the ["Stateful Chapters"](https://elm-book-in-elm-book.netlify.app/guides/stateful-chapters) guide for a more throughout explanation.
 
-@docs withStatefulComponent, withStatefulComponentList, renderStatefulComponent, renderStatefulComponentList
+@docs withStatefulComponent, withStatefulComponentList, renderStatefulComponent, renderStatefulComponentList, map
 
 
 # Customizing Chapters
@@ -297,6 +297,13 @@ renderWithComponentList : String -> ChapterBuilder state html -> ChapterCustom s
 renderWithComponentList body (ChapterBuilder builder) =
     Chapter
         { builder | body = builder.body ++ body ++ "\n<component-list />" }
+
+
+{-| Maps the msg a Chapter produces. Useful when using chapters that have their own `Msg` and `update` functions
+-}
+map : (subMsg -> mappedSubMsg) -> Chapter state subMsg -> Chapter state mappedSubMsg
+map mapMsg chapter_ =
+    ElmBook.Internal.Chapter.map (Html.map (ElmBook.Internal.Msg.map mapMsg)) chapter_
 
 
 

--- a/src/ElmBook/ComponentOptions.elm
+++ b/src/ElmBook/ComponentOptions.elm
@@ -9,7 +9,7 @@ By default, your components will appear inside a card with some padding and a la
 
 Customizations might be applied for your whole book, for a particular chapter or even for a particular component.
 
-    main : Book ()
+    main : Book () ()
     main =
         book "My Book"
             |> withComponentOptions

--- a/src/ElmBook/Custom.elm
+++ b/src/ElmBook/Custom.elm
@@ -7,19 +7,19 @@ module ElmBook.Custom exposing (Book, BookBuilder, Chapter, Msg, customBook)
     import Element exposing (Element, layout)
     import ElmBook.Custom exposing (customBook)
 
-    type alias Html state =
-        Element (ElmBook.Custom.Msg state)
+    type alias Html state subMsg =
+        Element (ElmBook.Custom.Msg state subMsg)
 
-    type alias BookBuilder state =
-        ElmBook.Custom.BookBuilder state (Html state)
+    type alias BookBuilder state subMsg =
+        ElmBook.Custom.BookBuilder state (Html state) subMsg
 
-    type alias Book state =
-        ElmBook.Custom.Book state (Html state)
+    type alias Book state subMsg =
+        ElmBook.Custom.Book state (Html state) subMsg
 
     type alias Chapter state =
         ElmBook.Custom.Chapter state (Html state)
 
-    book : String -> BookBuilder state
+    book : String -> BookBuilder state subMsg
     book =
         customBook (layout [])
 

--- a/src/ElmBook/Custom.elm
+++ b/src/ElmBook/Custom.elm
@@ -40,8 +40,8 @@ import Html exposing (Html)
 
 
 {-| -}
-type alias Msg state =
-    ElmBook.Internal.Msg.Msg state
+type alias Msg state subMsg =
+    ElmBook.Internal.Msg.Msg state subMsg
 
 
 {-| -}
@@ -50,17 +50,17 @@ type alias Chapter state html =
 
 
 {-| -}
-type alias BookBuilder state html =
-    ElmBook.Internal.Book.BookBuilder state html
+type alias BookBuilder state html subMsg =
+    ElmBook.Internal.Book.BookBuilder state html subMsg
 
 
 {-| -}
-type alias Book state html =
-    BookApplication state html
+type alias Book state html subMsg =
+    BookApplication state html subMsg
 
 
 {-| -}
-customBook : (html -> Html (Msg state)) -> String -> BookBuilder state html
+customBook : (html -> Html (Msg state subMsg)) -> String -> BookBuilder state html subMsg
 customBook toHtml title =
     BookBuilder
         { title = title

--- a/src/ElmBook/Internal/Application.elm
+++ b/src/ElmBook/Internal/Application.elm
@@ -214,6 +214,20 @@ update config msg model =
                                 )
                     )
 
+        GotCustomMsg subMsg ->
+            case model.state of
+                Nothing ->
+                    ( model, Cmd.none )
+
+                Just state ->
+                    let
+                        ( newState, cmd ) =
+                            config.statefulOptions.update subMsg state
+                    in
+                    ( { model | state = Just newState }
+                    , Cmd.map GotCustomMsg cmd
+                    )
+
         ToggleDarkMode ->
             let
                 darkMode =
@@ -362,9 +376,6 @@ update config msg model =
                 (\t -> { t | navAccentHighlight = Just navAccentHighlight })
 
         DoNothing ->
-            ( model, Cmd.none )
-
-        GenericMsg _ ->
             ( model, Cmd.none )
 
 

--- a/src/ElmBook/Internal/Application.elm
+++ b/src/ElmBook/Internal/Application.elm
@@ -58,14 +58,14 @@ type alias Model state html =
 -- Application
 
 
-type alias BookApplication state html =
-    Program () (Model state html) (Msg state)
+type alias BookApplication state html subMsg =
+    Program () (Model state html) (Msg state subMsg)
 
 
 application :
     List ( String, List (ChapterCustom state html) )
-    -> BookBuilder state html
-    -> BookApplication state html
+    -> BookBuilder state html subMsg
+    -> BookApplication state html subMsg
 application chapterGroups bookBuilder =
     let
         config =
@@ -95,11 +95,11 @@ application chapterGroups bookBuilder =
 
 
 init :
-    ElmBookConfig state html
+    ElmBookConfig state html subMsg
     -> ()
     -> Url.Url
     -> Browser.Navigation.Key
-    -> ( Model state html, Cmd (Msg state) )
+    -> ( Model state html, Cmd (Msg state subMsg) )
 init config _ url_ navKey =
     let
         url =
@@ -148,7 +148,7 @@ init config _ url_ navKey =
 -- Update
 
 
-update : ElmBookConfig state html -> Msg state -> Model state html -> ( Model state html, Cmd (Msg state) )
+update : ElmBookConfig state html subMsg -> Msg state subMsg -> Model state html -> ( Model state html, Cmd (Msg state subMsg) )
 update config msg model =
     let
         activeChapter =
@@ -364,16 +364,19 @@ update config msg model =
         DoNothing ->
             ( model, Cmd.none )
 
+        GenericMsg _ ->
+            ( model, Cmd.none )
+
 
 updateThemeOverrides :
     Model state html
     -> (ElmBook.Internal.ThemeOptions.ThemeOptionOverrides -> ElmBook.Internal.ThemeOptions.ThemeOptionOverrides)
-    -> ( Model state html, Cmd (Msg state) )
+    -> ( Model state html, Cmd (Msg state subMsg) )
 updateThemeOverrides model fn =
     ( { model | themeOverrides = fn model.themeOverrides }, Cmd.none )
 
 
-withActionLogReset : Model state html -> ( Model state html, Cmd (Msg state) ) -> ( Model state html, Cmd (Msg state) )
+withActionLogReset : Model state html -> ( Model state html, Cmd (Msg state subMsg) ) -> ( Model state html, Cmd (Msg state subMsg) )
 withActionLogReset previousModel =
     Tuple.mapFirst
         (\model ->
@@ -389,7 +392,7 @@ withActionLogReset previousModel =
 -- View
 
 
-view : ElmBookConfig state html -> Model state html -> Browser.Document (Msg state)
+view : ElmBookConfig state html subMsg -> Model state html -> Browser.Document (Msg state subMsg)
 view config model =
     let
         theme =
@@ -538,10 +541,10 @@ view config model =
 
 
 componentView :
-    (html -> Html (Msg state))
+    (html -> Html (Msg state subMsg))
     -> Maybe state
     -> ChapterComponentView state html
-    -> Html (Msg state)
+    -> Html (Msg state subMsg)
 componentView toHtml state_ componentView_ =
     case componentView_ of
         ChapterComponentViewStateless html ->
@@ -592,7 +595,7 @@ extractPath hashBasedNavigation url =
 -- Keyboard Events
 
 
-keyDownDecoder : Decode.Decoder (Msg state)
+keyDownDecoder : Decode.Decoder (Msg state subMsg)
 keyDownDecoder =
     Decode.map
         (\string ->
@@ -621,7 +624,7 @@ keyDownDecoder =
         (Decode.field "key" Decode.string)
 
 
-keyUpDecoder : Decode.Decoder (Msg state)
+keyUpDecoder : Decode.Decoder (Msg state subMsg)
 keyUpDecoder =
     Decode.map
         (\string ->

--- a/src/ElmBook/Internal/Book.elm
+++ b/src/ElmBook/Internal/Book.elm
@@ -20,28 +20,28 @@ import Html exposing (Html)
 -- Builder
 
 
-type alias BookBuilderData state html =
+type alias BookBuilderData state html subMsg =
     { title : String
-    , toHtml : html -> Html (Msg state)
-    , statefulOptions : StatefulOptions state
+    , toHtml : html -> Html (Msg state subMsg)
+    , statefulOptions : StatefulOptions state subMsg
     , themeOptions : ThemeOptions html
     , chapterOptions : ValidChapterOptions
     , componentOptions : ValidComponentOptions
     }
 
 
-type BookBuilder state html
-    = BookBuilder (BookBuilderData state html)
+type BookBuilder state html subMsg
+    = BookBuilder (BookBuilderData state html subMsg)
 
 
 
 -- Config
 
 
-type alias ElmBookConfig state html =
+type alias ElmBookConfig state html subMsg =
     { title : String
-    , toHtml : html -> Html (Msg state)
-    , statefulOptions : StatefulOptions state
+    , toHtml : html -> Html (Msg state subMsg)
+    , statefulOptions : StatefulOptions state subMsg
     , themeOptions : ThemeOptions html
     , chapterOptions : ValidChapterOptions
     , componentOptions : ValidComponentOptions
@@ -53,8 +53,8 @@ type alias ElmBookConfig state html =
 
 configFromBuilder :
     List ( String, List (ChapterCustom state html) )
-    -> BookBuilder state html
-    -> ElmBookConfig state html
+    -> BookBuilder state html subMsg
+    -> ElmBookConfig state html subMsg
 configFromBuilder chapterGroups_ (BookBuilder data) =
     let
         chapterData :
@@ -127,7 +127,7 @@ configFromBuilder chapterGroups_ (BookBuilder data) =
 -- Helpers
 
 
-chapterFromUrl : ElmBookConfig state html -> String -> Maybe (ChapterCustom state html)
+chapterFromUrl : ElmBookConfig state html subMsg -> String -> Maybe (ChapterCustom state html)
 chapterFromUrl config url =
     Dict.get url config.chapterByUrl
         |> Maybe.andThen (\i -> Array.get i config.chapters)

--- a/src/ElmBook/Internal/Chapter.elm
+++ b/src/ElmBook/Internal/Chapter.elm
@@ -15,6 +15,7 @@ module ElmBook.Internal.Chapter exposing
     , defaultOptions
     , defaultOverrides
     , groupTitle
+    , map
     , toValidOptions
     )
 
@@ -49,6 +50,33 @@ defaultOverrides =
 toValidOptions : ValidChapterOptions -> ChapterOptions -> ValidChapterOptions
 toValidOptions valid (ChapterOptions options) =
     { hiddenTitle = Maybe.withDefault valid.hiddenTitle options.hiddenTitle
+    }
+
+
+map : (html -> mappedHtml) -> ChapterCustom state html -> ChapterCustom state mappedHtml
+map mapFn (Chapter chapter) =
+    Chapter
+        { url = chapter.url
+        , title = chapter.title
+        , internal = chapter.internal
+        , groupTitle = chapter.groupTitle
+        , body = chapter.body
+        , chapterOptions = chapter.chapterOptions
+        , componentOptions = chapter.componentOptions
+        , componentList = List.map (mapComponent mapFn) chapter.componentList
+        }
+
+
+mapComponent : (html -> mappedHtml) -> ChapterComponent state html -> ChapterComponent state mappedHtml
+mapComponent mapFn component =
+    { label = component.label
+    , view =
+        case component.view of
+            ChapterComponentViewStateless statelessView ->
+                ChapterComponentViewStateless (mapFn statelessView)
+
+            ChapterComponentViewStateful statefulView ->
+                ChapterComponentViewStateful (statefulView >> mapFn)
     }
 
 

--- a/src/ElmBook/Internal/Msg.elm
+++ b/src/ElmBook/Internal/Msg.elm
@@ -4,11 +4,12 @@ import Browser exposing (UrlRequest)
 import Url exposing (Url)
 
 
-type Msg state
+type Msg state msg
     = DoNothing
     | OnUrlRequest UrlRequest
     | OnUrlChange Url
-    | UpdateState (state -> ( state, Cmd (Msg state) ))
+    | GenericMsg msg
+    | UpdateState (state -> ( state, Cmd (Msg state msg) ))
     | LogAction String String
     | ToggleDarkMode
     | ActionLogShow

--- a/src/ElmBook/Internal/Msg.elm
+++ b/src/ElmBook/Internal/Msg.elm
@@ -1,4 +1,4 @@
-module ElmBook.Internal.Msg exposing (Msg(..))
+module ElmBook.Internal.Msg exposing (Msg(..), map)
 
 import Browser exposing (UrlRequest)
 import Url exposing (Url)
@@ -8,7 +8,7 @@ type Msg state msg
     = DoNothing
     | OnUrlRequest UrlRequest
     | OnUrlChange Url
-    | GenericMsg msg
+    | GotCustomMsg msg
     | UpdateState (state -> ( state, Cmd (Msg state msg) ))
     | LogAction String String
     | ToggleDarkMode
@@ -32,3 +32,88 @@ type Msg state msg
     | SetThemeNavBackground String
     | SetThemeNavAccent String
     | SetThemeNavAccentHighlight String
+
+
+map : (msg -> mappedMsg) -> Msg state msg -> Msg state mappedMsg
+map mapMsg msg =
+    case msg of
+        DoNothing ->
+            DoNothing
+
+        OnUrlRequest urlRequest ->
+            OnUrlRequest urlRequest
+
+        OnUrlChange url ->
+            OnUrlChange url
+
+        GotCustomMsg subMsg ->
+            GotCustomMsg (mapMsg subMsg)
+
+        UpdateState fn ->
+            UpdateState (fn >> Tuple.mapSecond (Cmd.map (map mapMsg)))
+
+        LogAction context action ->
+            LogAction context action
+
+        ToggleDarkMode ->
+            ToggleDarkMode
+
+        ActionLogShow ->
+            ActionLogShow
+
+        ActionLogHide ->
+            ActionLogHide
+
+        SearchFocus ->
+            SearchFocus
+
+        SearchBlur ->
+            SearchBlur
+
+        Search value ->
+            Search value
+
+        ToggleMenu ->
+            ToggleMenu
+
+        KeyArrowDown ->
+            KeyArrowDown
+
+        KeyArrowUp ->
+            KeyArrowUp
+
+        KeyShiftOn ->
+            KeyShiftOn
+
+        KeyShiftOff ->
+            KeyShiftOff
+
+        KeyMetaOn ->
+            KeyMetaOn
+
+        KeyMetaOff ->
+            KeyMetaOff
+
+        KeyEnter ->
+            KeyEnter
+
+        KeyK ->
+            KeyK
+
+        SetThemeBackgroundGradient startColor endColor ->
+            SetThemeBackgroundGradient startColor endColor
+
+        SetThemeBackground background ->
+            SetThemeBackground background
+
+        SetThemeAccent accent ->
+            SetThemeAccent accent
+
+        SetThemeNavBackground navBackground ->
+            SetThemeNavBackground navBackground
+
+        SetThemeNavAccent navAccent ->
+            SetThemeNavAccent navAccent
+
+        SetThemeNavAccentHighlight navAccentHighlight ->
+            SetThemeNavAccentHighlight navAccentHighlight

--- a/src/ElmBook/Internal/StatefulOptions.elm
+++ b/src/ElmBook/Internal/StatefulOptions.elm
@@ -8,6 +8,7 @@ import ElmBook.Internal.Msg exposing (Msg)
 
 type alias StatefulOptions state subMsg =
     { initialState : Maybe state
+    , update : subMsg -> state -> ( state, Cmd subMsg )
     , onDarkModeChange : Bool -> state -> state
     , subscriptions : List (Sub (Msg state subMsg))
     }
@@ -16,6 +17,7 @@ type alias StatefulOptions state subMsg =
 defaultOptions : StatefulOptions state subMsg
 defaultOptions =
     { initialState = Nothing
+    , update = \_ state -> ( state, Cmd.none )
     , onDarkModeChange = \_ -> identity
     , subscriptions = []
     }

--- a/src/ElmBook/Internal/StatefulOptions.elm
+++ b/src/ElmBook/Internal/StatefulOptions.elm
@@ -6,14 +6,14 @@ module ElmBook.Internal.StatefulOptions exposing
 import ElmBook.Internal.Msg exposing (Msg)
 
 
-type alias StatefulOptions state =
+type alias StatefulOptions state subMsg =
     { initialState : Maybe state
     , onDarkModeChange : Bool -> state -> state
-    , subscriptions : List (Sub (Msg state))
+    , subscriptions : List (Sub (Msg state subMsg))
     }
 
 
-defaultOptions : StatefulOptions state
+defaultOptions : StatefulOptions state subMsg
 defaultOptions =
     { initialState = Nothing
     , onDarkModeChange = \_ -> identity

--- a/src/ElmBook/StatefulOptions.elm
+++ b/src/ElmBook/StatefulOptions.elm
@@ -21,8 +21,8 @@ import ElmBook.Internal.StatefulOptions exposing (StatefulOptions)
 
 
 {-| -}
-type alias Attribute state =
-    StatefulOptions state -> StatefulOptions state
+type alias Attribute state subMsg =
+    StatefulOptions state subMsg -> StatefulOptions state subMsg
 
 
 {-| Add an initial state to your book.
@@ -38,7 +38,7 @@ type alias Attribute state =
         ]
 
 -}
-initialState : state -> Attribute state
+initialState : state -> Attribute state subMsg
 initialState state options =
     { options | initialState = Just state }
 
@@ -68,7 +68,7 @@ initialState state options =
         ]
 
 -}
-subscriptions : List (Sub (Msg state)) -> Attribute state
+subscriptions : List (Sub (Msg state subMsg)) -> Attribute state subMsg
 subscriptions subscriptions_ options =
     { options | subscriptions = subscriptions_ }
 
@@ -98,6 +98,6 @@ This can be useful for showcasing your own dark themed components when using elm
             ]
 
 -}
-onDarkModeChange : (Bool -> state -> state) -> Attribute state
+onDarkModeChange : (Bool -> state -> state) -> Attribute state subMsg
 onDarkModeChange onDarkModeChange_ options =
     { options | onDarkModeChange = onDarkModeChange_ }

--- a/src/ElmBook/StatefulOptions.elm
+++ b/src/ElmBook/StatefulOptions.elm
@@ -1,14 +1,13 @@
 module ElmBook.StatefulOptions exposing
-    ( initialState, subscriptions, onDarkModeChange
+    ( initialState, update, subscriptions, onDarkModeChange
     , Attribute
-    , update
     )
 
 {-| Attributes used by `ElmBook.withStatefulOptions`.
 
 The attributes below are mostly used for Stateful Books. Take a look at the ["Stateful Chapters"](https://elm-book-in-elm-book.netlify.app/guides/stateful-chapters) guide for more details.
 
-@docs initialState, subscriptions, onDarkModeChange
+@docs initialState, update, subscriptions, onDarkModeChange
 
 
 # Types
@@ -32,7 +31,7 @@ type alias Attribute state subMsg =
         { value : String }
 
 
-    book : Book SharedState
+    book : Book SharedState y
     book "MyApp"
         |> withStatefulOptions [
             initialState { value = "" }
@@ -91,7 +90,7 @@ update updateFn options =
         { state | timestamp = posix }
 
 
-    book : Book SharedState
+    book : Book SharedState y
     book "MyApp"
         |> withStatefulOptions [
             subscriptions [
@@ -119,7 +118,7 @@ This can be useful for showcasing your own dark themed components when using elm
         { darkMode = False
         }
 
-    book : Book SharedState
+    book : Book SharedState y
     book "MyApp"
         |> withStatefulOptions
             [ ElmBook.StatefulOptions.initialState

--- a/src/ElmBook/StatefulOptions.elm
+++ b/src/ElmBook/StatefulOptions.elm
@@ -1,6 +1,7 @@
 module ElmBook.StatefulOptions exposing
     ( initialState, subscriptions, onDarkModeChange
     , Attribute
+    , update
     )
 
 {-| Attributes used by `ElmBook.withStatefulOptions`.
@@ -41,6 +42,38 @@ type alias Attribute state subMsg =
 initialState : state -> Attribute state subMsg
 initialState state options =
     { options | initialState = Just state }
+
+
+{-| Update the shared state with your own msg type.
+
+    type alias SharedState =
+        { childComponent : ChildComponent.Model }
+
+    type Msg
+        = GotChildComponentMsg ChildComponent.Msg
+
+    updateSharedState : SharedState -> Msg -> ( SharedState, Cmd Msg )
+    updateSharedState sharedState msg =
+        case msg of
+            UpdatedChildComponent subMsg ->
+                let
+                    ( childComponent, cmd ) =
+                        ChildComponent.update subMsg sharedState.childComponent
+                in
+                ( { sharedState | childComponent = childComponent }
+                , Cmd.map GotChildComponentMsg cmd
+                )
+
+    book : Book SharedState Msg
+    book "MyApp"
+        |> withStatefulOptions [
+            update updateSharedState
+        ]
+
+-}
+update : (subMsg -> state -> ( state, Cmd subMsg )) -> Attribute state subMsg
+update updateFn options =
+    { options | update = updateFn }
 
 
 {-| Add subscriptions to your book.

--- a/src/ElmBook/UI/Chapter.elm
+++ b/src/ElmBook/UI/Chapter.elm
@@ -12,12 +12,12 @@ import Html exposing (..)
 import Html.Attributes exposing (..)
 
 
-type alias Props state =
+type alias Props state subMsg =
     { title : String
     , chapterOptions : ElmBook.Internal.Chapter.ValidChapterOptions
     , componentOptions : ElmBook.Internal.ComponentOptions.ValidComponentOptions
     , body : String
-    , components : List ( String, Html.Html (Msg state) )
+    , components : List ( String, Html.Html (Msg state subMsg) )
     }
 
 
@@ -36,7 +36,7 @@ styles =
 """
 
 
-view : Props state -> Html (Msg state)
+view : Props state subMsg -> Html (Msg state subMsg)
 view props =
     let
         body =

--- a/src/ElmBook/UI/ChapterComponent.elm
+++ b/src/ElmBook/UI/ChapterComponent.elm
@@ -39,7 +39,7 @@ styles =
 """
 
 
-viewLabel : ValidComponentOptions -> String -> Html (Msg state)
+viewLabel : ValidComponentOptions -> String -> Html (Msg state subMsg)
 viewLabel options_ label =
     case ( label, options_.hiddenLabel, options_.display ) of
         ( "", _, _ ) ->
@@ -58,7 +58,7 @@ viewLabel options_ label =
                 [ text label ]
 
 
-viewBlock : ValidComponentOptions -> ( String, Html.Html (Msg state) ) -> Html (Msg state)
+viewBlock : ValidComponentOptions -> ( String, Html.Html (Msg state subMsg) ) -> Html (Msg state subMsg)
 viewBlock options_ ( label, html ) =
     article
         [ class "elm-book__chapter-component" ]
@@ -67,7 +67,7 @@ viewBlock options_ ( label, html ) =
         ]
 
 
-viewCard : ValidComponentOptions -> ( String, Html.Html (Msg state) ) -> Html (Msg state)
+viewCard : ValidComponentOptions -> ( String, Html.Html (Msg state subMsg) ) -> Html (Msg state subMsg)
 viewCard options_ ( label, html ) =
     article
         [ class "elm-book__chapter-component" ]
@@ -83,7 +83,7 @@ viewCard options_ ( label, html ) =
         ]
 
 
-viewDisplay : ValidComponentOptions -> ( String, Html.Html (Msg state) ) -> Html (Msg state)
+viewDisplay : ValidComponentOptions -> ( String, Html.Html (Msg state subMsg) ) -> Html (Msg state subMsg)
 viewDisplay options_ ( label, html ) =
     case options_.display of
         Inline ->
@@ -96,7 +96,7 @@ viewDisplay options_ ( label, html ) =
             viewCard options_ ( label, html )
 
 
-view : String -> ValidComponentOptions -> ( String, Html.Html (Msg state) ) -> Html (Msg state)
+view : String -> ValidComponentOptions -> ( String, Html.Html (Msg state subMsg) ) -> Html (Msg state subMsg)
 view chapterTitle options_ ( label, html ) =
     viewDisplay options_ ( label, html )
         |> Html.map

--- a/src/ElmBook/UI/Docs/ActionLog.elm
+++ b/src/ElmBook/UI/Docs/ActionLog.elm
@@ -5,7 +5,7 @@ import ElmBook.Chapter exposing (Chapter, chapter, renderWithComponentList, with
 import ElmBook.UI.ActionLog exposing (list, preview, previewEmpty)
 
 
-docs : Chapter x
+docs : Chapter x subMsg
 docs =
     chapter "ActionLog"
         |> withComponentList

--- a/src/ElmBook/UI/Docs/DarkModeComponents.elm
+++ b/src/ElmBook/UI/Docs/DarkModeComponents.elm
@@ -9,7 +9,7 @@ type alias SharedState x =
     { x | darkMode : Bool }
 
 
-docs : Chapter (SharedState x)
+docs : Chapter (SharedState x) subMsg
 docs =
     chapter "Dark Components"
         |> withStatefulComponent

--- a/src/ElmBook/UI/Docs/Guides/Books.elm
+++ b/src/ElmBook/UI/Docs/Guides/Books.elm
@@ -3,7 +3,7 @@ module ElmBook.UI.Docs.Guides.Books exposing (..)
 import ElmBook.Chapter exposing (Chapter, chapter, render)
 
 
-docs : Chapter x
+docs : Chapter x subMsg
 docs =
     chapter "Books"
         |> render """

--- a/src/ElmBook/UI/Docs/Guides/BuiltinServer.elm
+++ b/src/ElmBook/UI/Docs/Guides/BuiltinServer.elm
@@ -3,7 +3,7 @@ module ElmBook.UI.Docs.Guides.BuiltinServer exposing (..)
 import ElmBook.Chapter exposing (Chapter, chapter, render)
 
 
-docs : Chapter x
+docs : Chapter x subMsg
 docs =
     chapter "Development Server"
         |> render """

--- a/src/ElmBook/UI/Docs/Guides/Chapters.elm
+++ b/src/ElmBook/UI/Docs/Guides/Chapters.elm
@@ -3,7 +3,7 @@ module ElmBook.UI.Docs.Guides.Chapters exposing (..)
 import ElmBook.Chapter exposing (Chapter, chapter, render)
 
 
-docs : Chapter x
+docs : Chapter x subMsg
 docs =
     chapter "Chapters"
         |> render """

--- a/src/ElmBook/UI/Docs/Guides/Interop.elm
+++ b/src/ElmBook/UI/Docs/Guides/Interop.elm
@@ -3,7 +3,7 @@ module ElmBook.UI.Docs.Guides.Interop exposing (docs)
 import ElmBook.Chapter exposing (Chapter, chapter, render)
 
 
-docs : Chapter x
+docs : Chapter x subMsg
 docs =
     chapter "Elm-UI and Elm-CSS"
         |> render """

--- a/src/ElmBook/UI/Docs/Guides/LoggingActions.elm
+++ b/src/ElmBook/UI/Docs/Guides/LoggingActions.elm
@@ -9,7 +9,7 @@ import Html.Attributes exposing (..)
 import Html.Events exposing (..)
 
 
-docs : Chapter x
+docs : Chapter x subMsg
 docs =
     chapter "Logging Actions"
         |> withComponentOptions

--- a/src/ElmBook/UI/Docs/Guides/StatefulChapters.elm
+++ b/src/ElmBook/UI/Docs/Guides/StatefulChapters.elm
@@ -5,7 +5,7 @@ import Html exposing (..)
 import Html.Attributes exposing (..)
 
 
-docs : Chapter x
+docs : Chapter x subMsg
 docs =
     chapter "Stateful Chapters"
         |> render """

--- a/src/ElmBook/UI/Docs/Guides/Theming.elm
+++ b/src/ElmBook/UI/Docs/Guides/Theming.elm
@@ -15,7 +15,7 @@ import Html.Attributes exposing (..)
 import Html.Events exposing (..)
 
 
-docs : Chapter (ElmBook.UI.ThemeGenerator.SharedState m)
+docs : Chapter (ElmBook.UI.ThemeGenerator.SharedState m) subMsg
 docs =
     let
         headerProps =

--- a/src/ElmBook/UI/Docs/HeaderNavFooter.elm
+++ b/src/ElmBook/UI/Docs/HeaderNavFooter.elm
@@ -10,7 +10,7 @@ import ElmBook.UI.Helpers exposing (themeBackground)
 import ElmBook.UI.Search
 
 
-docs : Chapter x
+docs : Chapter x subMsg
 docs =
     chapter "Header, Nav & Footer"
         |> withComponentOptions

--- a/src/ElmBook/UI/Docs/HeaderNavFooter/Header.elm
+++ b/src/ElmBook/UI/Docs/HeaderNavFooter/Header.elm
@@ -11,7 +11,7 @@ import Html.Attributes exposing (..)
 import Html.Events exposing (..)
 
 
-docs : List ( String, Html (ElmBook.Msg x) )
+docs : List ( String, Html (ElmBook.Msg x subMsg) )
 docs =
     let
         props =

--- a/src/ElmBook/UI/Docs/HeaderNavFooter/Nav.elm
+++ b/src/ElmBook/UI/Docs/HeaderNavFooter/Nav.elm
@@ -5,7 +5,7 @@ import ElmBook.UI.Nav exposing (view)
 import Html exposing (..)
 
 
-docs : List ( String, Html (ElmBook.Msg x) )
+docs : List ( String, Html (ElmBook.Msg x subMsg) )
 docs =
     let
         itemGroup index =

--- a/src/ElmBook/UI/Docs/Icons.elm
+++ b/src/ElmBook/UI/Docs/Icons.elm
@@ -4,7 +4,7 @@ import ElmBook.Chapter exposing (Chapter, chapter, renderWithComponentList, with
 import ElmBook.UI.Icons exposing (..)
 
 
-docs : Chapter x
+docs : Chapter x subMsg
 docs =
     let
         color =

--- a/src/ElmBook/UI/Docs/Intro/Overview.elm
+++ b/src/ElmBook/UI/Docs/Intro/Overview.elm
@@ -5,7 +5,7 @@ import Html exposing (..)
 import Html.Attributes exposing (..)
 
 
-docs : Chapter x
+docs : Chapter x subMsg
 docs =
     chapter "Overview"
         |> render """

--- a/src/ElmBook/UI/Docs/Markdown.elm
+++ b/src/ElmBook/UI/Docs/Markdown.elm
@@ -3,7 +3,7 @@ module ElmBook.UI.Docs.Markdown exposing (..)
 import ElmBook.Chapter exposing (Chapter, chapter, render)
 
 
-docs : Chapter x
+docs : Chapter x subMsg
 docs =
     chapter "Markdown"
         |> render """

--- a/src/ElmBook/UI/Docs/ThemeGenerator.elm
+++ b/src/ElmBook/UI/Docs/ThemeGenerator.elm
@@ -4,7 +4,7 @@ import ElmBook.Chapter exposing (Chapter, chapter, render, withStatefulComponent
 import ElmBook.UI.ThemeGenerator
 
 
-docs : Chapter (ElmBook.UI.ThemeGenerator.SharedState m)
+docs : Chapter (ElmBook.UI.ThemeGenerator.SharedState m) subMsg
 docs =
     chapter "Theme Generator"
         |> withStatefulComponent ElmBook.UI.ThemeGenerator.view

--- a/src/ElmBook/UI/Docs/Wrapper.elm
+++ b/src/ElmBook/UI/Docs/Wrapper.elm
@@ -8,7 +8,7 @@ import Html exposing (..)
 import Html.Attributes exposing (..)
 
 
-docs : Chapter x
+docs : Chapter x subMsg
 docs =
     let
         props =

--- a/src/ElmBook/UI/ElmBook.elm
+++ b/src/ElmBook/UI/ElmBook.elm
@@ -49,7 +49,7 @@ initialState =
     }
 
 
-main : Book SharedState
+main : Book SharedState subMsg
 main =
     book "ElmBook's"
         |> withStatefulOptions

--- a/src/ElmBook/UI/Markdown.elm
+++ b/src/ElmBook/UI/Markdown.elm
@@ -17,7 +17,7 @@ import Markdown.Renderer
 import SyntaxHighlight
 
 
-view : String -> List ( String, Html (Msg state) ) -> ElmBook.Internal.ComponentOptions.ValidComponentOptions -> String -> Html (Msg state)
+view : String -> List ( String, Html (Msg state subMsg) ) -> ElmBook.Internal.ComponentOptions.ValidComponentOptions -> String -> Html (Msg state subMsg)
 view chapterTitle chapterComponents componentOptions =
     Markdown.Parser.parse
         >> Result.withDefault []
@@ -36,7 +36,7 @@ view chapterTitle chapterComponents componentOptions =
            )
 
 
-componentRenderer : String -> List ( String, Html (Msg state) ) -> ElmBook.Internal.ComponentOptions.ValidComponentOptions -> Markdown.Renderer.Renderer (Html (Msg state))
+componentRenderer : String -> List ( String, Html (Msg state subMsg) ) -> ElmBook.Internal.ComponentOptions.ValidComponentOptions -> Markdown.Renderer.Renderer (Html (Msg state subMsg))
 componentRenderer chapterTitle chapterComponents componentOptions =
     { defaultRenderer
         | html =

--- a/src/ElmBook/UI/ThemeGenerator.elm
+++ b/src/ElmBook/UI/ThemeGenerator.elm
@@ -32,7 +32,7 @@ type Msg_
     | UpdateNavAccentHighlight_ String
 
 
-update : Msg_ -> SharedState m -> ( SharedState m, Cmd (ElmBook.Internal.Msg.Msg (SharedState m)) )
+update : Msg_ -> SharedState m -> ( SharedState m, Cmd (ElmBook.Internal.Msg.Msg (SharedState m) subMsg) )
 update msg sharedState =
     let
         model =
@@ -85,7 +85,7 @@ update msg sharedState =
     ( { sharedState | theming = model_ }, cmd )
 
 
-view : SharedState m -> Html (Msg (SharedState m))
+view : SharedState m -> Html (Msg (SharedState m) subMsg)
 view { theming } =
     div
         [ class "elm-book-theme-builder" ]


### PR DESCRIPTION
Closes #12 

Changes:
- Add a `GotCustomMsg` constructor on `ElmBook.Internal.Msg.Msg`
- Add `update` on `ElmBook.StatefulOptions`
- Add a `CustomChapter` type to make it easier to use chapters with custom msgs
- Add `Chapter.map` and `Chapter.mapCustom`
- Update docs to reflect the new types
- Add docs to the relevant parts