### PR TITLE
feat: withChapterInit and mapUpdate* helpers

### DIFF
--- a/src/ElmBook/Chapter.elm
+++ b/src/ElmBook/Chapter.elm
@@ -1,7 +1,7 @@
 module ElmBook.Chapter exposing
     ( chapter, chapterLink, renderComponent, renderComponentList, Chapter
     , withComponent, withComponentList, render, renderWithComponentList
-    , withStatefulComponent, withStatefulComponentList, renderStatefulComponent, renderStatefulComponentList
+    , withStatefulComponent, withStatefulComponentList, renderStatefulComponent, renderStatefulComponentList, withChapterInit
     , withChapterOptions, withComponentOptions
     )
 
@@ -69,7 +69,7 @@ Create chapters with interactive components that can read and update the book's 
 
 Take a look at the ["Stateful Chapters"](https://elm-book-in-elm-book.netlify.app/guides/stateful-chapters) guide for a more throughout explanation.
 
-@docs withStatefulComponent, withStatefulComponentList, renderStatefulComponent, renderStatefulComponentList
+@docs withStatefulComponent, withStatefulComponentList, renderStatefulComponent, renderStatefulComponentList, withChapterInit
 
 
 # Customizing Chapters
@@ -105,6 +105,7 @@ chapter title =
         , chapterOptions = ElmBook.Internal.Chapter.defaultOverrides
         , componentOptions = ElmBook.Internal.ComponentOptions.defaultOverrides
         , componentList = []
+        , init = Nothing
         }
 
 
@@ -124,6 +125,7 @@ chapterLink props =
         , chapterOptions = ElmBook.Internal.Chapter.defaultOverrides
         , componentOptions = ElmBook.Internal.ComponentOptions.defaultOverrides
         , componentList = []
+        , init = Nothing
         }
 
 
@@ -301,6 +303,16 @@ renderWithComponentList body (ChapterBuilder builder) =
 
 
 -- Customizing the chapter
+
+
+{-| Use this to trigger a state change or command whenever this chapter is first rendered.
+-}
+withChapterInit :
+    (state -> ( state, Cmd (Msg state) ))
+    -> ChapterBuilder state html
+    -> ChapterBuilder state html
+withChapterInit init_ (ChapterBuilder builder) =
+    ChapterBuilder { builder | init = Just init_ }
 
 
 {-| By default, your chapter will display its title at the top of the content. You can disable this by passing in chapter options.

--- a/src/ElmBook/Internal/Chapter.elm
+++ b/src/ElmBook/Internal/Chapter.elm
@@ -15,11 +15,13 @@ module ElmBook.Internal.Chapter exposing
     , defaultOptions
     , defaultOverrides
     , groupTitle
+    , init
     , toValidOptions
     )
 
 import ElmBook.Internal.ComponentOptions exposing (ComponentOptions)
 import ElmBook.Internal.Helpers exposing (toSlug)
+import ElmBook.Internal.Msg exposing (Msg)
 
 
 type alias ValidChapterOptions =
@@ -69,6 +71,7 @@ type alias ChapterConfig state html =
     , chapterOptions : ChapterOptions
     , componentOptions : ComponentOptions
     , componentList : List (ChapterComponent state html)
+    , init : Maybe (state -> ( state, Cmd (Msg state) ))
     }
 
 
@@ -110,6 +113,11 @@ chapterNavUrl hashBasedNavigation (Chapter { url, internal }) =
 groupTitle : ChapterCustom state html -> Maybe String
 groupTitle (Chapter chapter) =
     chapter.groupTitle
+
+
+init : ChapterCustom state html -> Maybe (state -> ( state, Cmd (Msg state) ))
+init (Chapter chapter) =
+    chapter.init
 
 
 chapterBreadcrumb : ChapterCustom state html -> String

--- a/src/ElmBook/UI/Docs/Guides/StatefulChapters.elm
+++ b/src/ElmBook/UI/Docs/Guides/StatefulChapters.elm
@@ -164,16 +164,19 @@ chapter =
 
 ---
 
-### Nested Elm Architecture Example
+### Nested Elm Architecture
 
-Let's change our `InputChapter` so it now have it's own elm architecture.
+Sometimes we need to handle components with their own msg, model and update. Well – turns out it can be pretty simple to use that on your elm-book!
 
 ```elm
 module InputChapter exposing (Model, init, chapter)
 
 
 import ElmBook.Chapter exposing (Chapter, chapter, renderStatefulComponent)
-import ElmBook.Actions exposing (updateStateWith)
+import ElmBook.Actions exposing (mapUpdate)
+
+
+-- component
 
 
 type alias Model = { value = String }
@@ -195,22 +198,22 @@ view model =
     input [ value model.value, onInput UpdateValue ] []
 
 
-type alias SharedState
-    = { x | inputModel : Model }
+-- elm-book
 
 
-updateSharedState : Msg -> SharedState -> SharedState
-updateSharedState msg shared =
-    { shared | inputModel = update msg shared.inputModel }
-
-
-chapter : ElmBook.Chapter SharedState
+chapter : ElmBook.Chapter { x | inputModel : Model }
 chapter =
     ElmBook.chapter "InputChapter"
         |> withStatefulComponent (
             \\{ inputModel } ->
                 view inputModel
-                    |> Html.map (updateStateWith updateSharedState)
+                    |> Html.map (
+                        mapUpdate
+                            { toState = \\state inputModel_ -> { state | inputModel = inputModel_ }
+                            , fromState = \\state -> state.inputModel
+                            , update = update
+                            }
+                    )
         )
 ```
 


### PR DESCRIPTION
This PR adds two new features to elm-book.

**ElmBook.Chapter.withChapterInit**

This can be used to trigger state changes and commands whenever the user renders a chapter. It will be re-triggered when the user navigates to a different chapter and gets back.

**ElmBook.Actions.updateMap** and **ElmBook.Actions.updateMapWithCmd**

These two helpers can be used to simplify the setup for docs with nested elm architectures.

