### PR TITLE
fix: Extensible record syntax

### DIFF
--- a/src/ElmBook/UI/Docs/Guides/StatefulChapters.elm
+++ b/src/ElmBook/UI/Docs/Guides/StatefulChapters.elm
@@ -107,16 +107,16 @@ import ElmBook.Actions exposing (updateState)
 type alias Model = Int
 
 
-type alias SharedState
+type alias SharedState x
     = { x | counterModel : Model }
 
 
-updateSharedState : SharedState -> SharedState
+updateSharedState : SharedState x -> SharedState x
 updateSharedState x =
     { x | counterModel = x.counterModel + 1 }
 
 
-chapter : Chapter SharedState
+chapter : Chapter (SharedState x)
 chapter =
     chapter "InputChapter"
         |> renderStatefulComponent (
@@ -141,16 +141,16 @@ import ElmBook.Actions exposing (updateStateWith)
 type alias Model = { value : String }
 
 
-type alias SharedState
+type alias SharedState x
     = { x | inputModel : Model }
 
 
-updateSharedState : Int -> SharedState -> SharedState
+updateSharedState : Int -> SharedState x -> SharedState x
 updateSharedState value x =
     { x | inputModel = { value = value } }
 
 
-chapter : ElmBook.Chapter SharedState
+chapter : ElmBook.Chapter (SharedState x)
 chapter =
     ElmBook.chapter "InputChapter"
         |> withStatefulComponent (


### PR DESCRIPTION
Extensible record syntax was not quite right in the documentation. Just needed the `x` argument.

<img width="747" alt="Screen Shot 2022-05-14 at 8 51 50 pm" src="https://user-images.githubusercontent.com/25443812/168423550-7e55b157-ca6e-4b95-80ea-d13dde7e4b6b.png">
