### PR TITLE
Fix navigation search behaviour

### DIFF
--- a/src/ElmBook/Internal/Application.elm
+++ b/src/ElmBook/Internal/Application.elm
@@ -494,7 +494,7 @@ view config model =
                         activeChapter
                             |> Maybe.map (chapterNavUrl hashBasedNavigation)
                     , preSelected =
-                        if model.isSearching then
+                        if model.isSearching && (Array.length chaptersList > 0) then
                             Array.get
                                 (modBy (Array.length chaptersList) model.chapterPreSelected)
                                 chaptersList

--- a/src/ElmBook/Internal/Application.elm
+++ b/src/ElmBook/Internal/Application.elm
@@ -340,11 +340,15 @@ update config msg model =
 
             else
                 let
-                    preSelectedIndex =
-                        modBy (Array.length config.chapters) model.chapterPreSelected
+                    filteredChapters =
+                        searchChapters model.search config.chapters
 
                     targetChapter =
-                        Array.get preSelectedIndex config.chapters
+                        if Array.isEmpty filteredChapters then
+                            Nothing
+                        else
+                            filteredChapters
+                                |> Array.get (modBy (Array.length filteredChapters) model.chapterPreSelected)
                 in
                 case targetChapter of
                     Just chapter_ ->


### PR DESCRIPTION
# Description

This PR fixes 2 navigation behaviour problems:
* When searching for a keyword that doesn't have a match in the navigation, the application breaks
* When searching for a keyword and navigating the nav items with arrow keys, "Enter" opens incorrect pages


## Steps to reproduce

issue 1:
* open ElmBooks's guide
* open the browser console
* type 'x' in the search field
* Elm runtime will throw `Uncaught Error: Cannot perform mod 0. Division by zero error.` when trying to run the `view` function.

issue 2:
* open ElmBooks's guide
* type 'h' in the search field
* navigate to "Header, Nav & Footer" page with arrow keys
* press enter key
* application will navigate to Books instead of the requested page


## Solution

The first issue was a modBy 0 error in the view function, which can be solved with an extra guard in place. I'd suggest wrapping the `modBy` function in `safeModBy` or similar, that returns `Maybe Int`, to be safer here, and make sure this issue doesn't come back in the future. There's also an elm-review rule for checking against unsafe `modBy` calls: https://package.elm-lang.org/packages/vkfisher/elm-review-no-unsafe-division/latest/

For the second one, we just need to take search state into account when handling `KeyEnter`. This branch also avoids division by 0 now, which was technically possible before, if ElmBook was initialised without any chapters.
