### PR TITLE
fix: avoid infinite loop when hitting an inexistent route

### DIFF
--- a/src/ElmBook/Internal/Application.elm
+++ b/src/ElmBook/Internal/Application.elm
@@ -206,7 +206,17 @@ update config msg model =
             case url of
                 "/" ->
                     Array.get 0 config.chapters
-                        |> Maybe.map (\fallback -> ( model, Browser.Navigation.pushUrl model.navKey <| chapterUrl fallback ))
+                        |> Maybe.map
+                            (\fallback ->
+                                ( model
+                                , Browser.Navigation.pushUrl model.navKey <|
+                                    if hashBasedNavigation_ then
+                                        "#" ++ chapterUrl fallback
+
+                                    else
+                                        chapterUrl fallback
+                                )
+                            )
                         |> Maybe.withDefault ( { model | url = "/" }, Cmd.none )
 
                 _ ->
@@ -346,6 +356,7 @@ update config msg model =
                     targetChapter =
                         if Array.isEmpty filteredChapters then
                             Nothing
+
                         else
                             filteredChapters
                                 |> Array.get (modBy (Array.length filteredChapters) model.chapterPreSelected)


### PR DESCRIPTION
closes #48 

## Testing the pr

When testing the pr, remember to
1. Add `ElmBook.ThemeOptions.useHashBasedNavigation` in the UI/ElmBook.elm file
2. Modify a chapter so to add an inexistent link to test the bugfix 

FYI: The links **must** be in this format `#/guides/inexistent`


## Rationale

When hashBasedNavigation is true and a route that can't be found among the chapters is hit, this is what happens:

1. OnUrlChange is triggered
2. `extractPath url_` is called and returns `/guides/inexistent` (url.fragment) which is then assigned to `url`
3. The catch all "\_" case executes
4. An urlChapter can't be found so it goes in the `Nothing` case
5. The `Nothing` case navigates to `#/`
6. The OnUrlChange is triggered again
7. `extractPath url_` is called and returns `/` (`url.fragment` is `Nothing` hence `Maybe.withDefault` kicks in) which is then assigned to `url`
8. The "\/" case executes
9. It gets the fallback chapter's url (`/overview` in the case of this repo) and navigates there, which is a problem because we have hashBasedNavigation set to true
10. The OnUrlChange is triggered again
11. `extractPath url_` is called and when hashBasedNavigation is true it returns the fragment or `/` and in the case of `/overview` the fragment is Nothing.
12. From now on it repeats from 8 to 12 infinitely 

![Screenshot 2024-08-21 at 20 52 51](https://github.com/user-attachments/assets/492ae249-09ce-4b5e-a992-62d6e4b59bc1)

## Solution

How do we stop it? Should be simple honestly, when the fallback chapter is retrieved, let's add the hashtag on front.


### Screencast


https://github.com/user-attachments/assets/669b83f2-15fd-409f-9774-57412e7940c1


