### PR TITLE
Remove heading links when using hash-based navigation

### DIFF
--- a/src/ElmBook/Internal/Application.elm
+++ b/src/ElmBook/Internal/Application.elm
@@ -5,7 +5,6 @@ module ElmBook.Internal.Application exposing
     , init
     )
 
-
 import Array exposing (Array)
 import Browser
 import Browser.Dom
@@ -29,9 +28,9 @@ import ElmBook.UI.Styles
 import ElmBook.UI.Wrapper
 import Html exposing (Html, text)
 import Json.Decode as Decode
+import Json.Encode
 import Task
 import Url
-import Json.Encode
 
 
 
@@ -556,6 +555,7 @@ view config model =
                                     activeChapter_.componentOptions
                                         |> ElmBook.Internal.ComponentOptions.toValidOptions
                                             config.componentOptions
+                                , hashBasedNavigation = config.themeOptions.hashBasedNavigation
                                 , body = activeChapter_.body
                                 , components =
                                     activeChapter_.componentList

--- a/src/ElmBook/UI/Chapter.elm
+++ b/src/ElmBook/UI/Chapter.elm
@@ -16,6 +16,7 @@ type alias Props state =
     { title : String
     , chapterOptions : ElmBook.Internal.Chapter.ValidChapterOptions
     , componentOptions : ElmBook.Internal.ComponentOptions.ValidComponentOptions
+    , hashBasedNavigation : Bool
     , body : String
     , components : List ( String, Html.Html (Msg state) )
     }
@@ -49,6 +50,7 @@ view props =
     article
         [ class "elm-book elm-book-chapter" ]
         [ ElmBook.UI.Markdown.view
+            props.hashBasedNavigation
             props.title
             props.components
             props.componentOptions

--- a/src/ElmBook/UI/Markdown.elm
+++ b/src/ElmBook/UI/Markdown.elm
@@ -18,8 +18,8 @@ import Markdown.Renderer
 import SyntaxHighlight
 
 
-view : String -> List ( String, Html (Msg state) ) -> ElmBook.Internal.ComponentOptions.ValidComponentOptions -> String -> Html (Msg state)
-view chapterTitle chapterComponents componentOptions chapterContent =
+view : Bool -> String -> List ( String, Html (Msg state) ) -> ElmBook.Internal.ComponentOptions.ValidComponentOptions -> String -> Html (Msg state)
+view hashBasedNavigation chapterTitle chapterComponents componentOptions chapterContent =
     chapterContent
         |> Markdown.Parser.parse
         |> Result.mapError
@@ -32,6 +32,7 @@ view chapterTitle chapterComponents componentOptions chapterContent =
             (\blocks ->
                 Markdown.Renderer.render
                     (componentRenderer
+                        hashBasedNavigation
                         chapterTitle
                         chapterComponents
                         componentOptions
@@ -55,11 +56,11 @@ view chapterTitle chapterComponents componentOptions chapterContent =
            )
 
 
-componentRenderer : String -> List ( String, Html (Msg state) ) -> ElmBook.Internal.ComponentOptions.ValidComponentOptions -> Markdown.Renderer.Renderer (Html (Msg state))
-componentRenderer chapterTitle chapterComponents componentOptions =
+componentRenderer : Bool -> String -> List ( String, Html (Msg state) ) -> ElmBook.Internal.ComponentOptions.ValidComponentOptions -> Markdown.Renderer.Renderer (Html (Msg state))
+componentRenderer hashBasedNavigation chapterTitle chapterComponents componentOptions =
     let
         defaultRenderer_ =
-            defaultRenderer False
+            defaultRenderer hashBasedNavigation
     in
     { defaultRenderer_
         | html =


### PR DESCRIPTION
As the title says, this PR just plainly disables links in headings when using hash-based navigation, because they are broken right now.

I'd be happy to add tests if told more or less how or where!

A few details:

- I changed the code a tiny bit to use the already existing `toSlug` function to generate the ID.
- Some formatting changed, because of elm-format. I can undo if necessary.

# Visual demonstration

When hash-based navigation is on, headings look like this.

<img width="1245" height="442" alt="image" src="https://github.com/user-attachments/assets/5a13f13c-0720-42e4-bc44-0cf77444a427" />

And the following is when I add the `ElmBook.ThemeOptions.useHashBasedNavigation` option.

<img width="1245" height="442" alt="image" src="https://github.com/user-attachments/assets/4aa5d3a1-fed0-4a48-b96d-69a4ed36ebba" />